### PR TITLE
Don't write frist to Gosys from Kabin. Enough from Kabal.

### DIFF
--- a/src/main/kotlin/no/nav/klage/clients/gosysoppgave/OppgaveRequest.kt
+++ b/src/main/kotlin/no/nav/klage/clients/gosysoppgave/OppgaveRequest.kt
@@ -1,28 +1,13 @@
 package no.nav.klage.clients.gosysoppgave
 
 import com.fasterxml.jackson.annotation.JsonInclude
-import java.time.LocalDate
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 data class UpdateGosysOppgaveInput(
     val versjon: Int,
-    val fristFerdigstillelse: LocalDate?,
-    val mappeId: Long?,
-    val orgnr: String?,
-    val status: Status?,
     val endretAvEnhetsnr: String?,
     val tilordnetRessurs: String?,
     val tildeltEnhetsnr: String?,
-    val prioritet: Prioritet?,
-    val behandlingstema: String?,
-    val behandlingstype: String?,
-    val aktivDato: String?,
-    val oppgavetype: String?,
-    val tema: String?,
-    val journalpostId: String?,
-    val saksreferanse: String?,
-    val behandlesAvApplikasjon: String?,
-    val personident: String?,
     val beskrivelse: String?,
     val kommentar: Kommentar?,
 ) {

--- a/src/main/kotlin/no/nav/klage/service/AnkeService.kt
+++ b/src/main/kotlin/no/nav/klage/service/AnkeService.kt
@@ -86,7 +86,6 @@ class AnkeService(
                 logger.debug("Attempting Gosys-oppgave update")
                 gosysOppgaveService.updateGosysOppgave(
                     gosysOppgaveId = it,
-                    frist = frist,
                     tildeltSaksbehandlerIdent = registrering.saksbehandlerIdent,
                 )
             }

--- a/src/main/kotlin/no/nav/klage/service/GosysOppgaveService.kt
+++ b/src/main/kotlin/no/nav/klage/service/GosysOppgaveService.kt
@@ -8,7 +8,6 @@ import no.nav.klage.util.TokenUtil
 import no.nav.klage.util.getLogger
 import no.nav.klage.util.getSecureLogger
 import org.springframework.stereotype.Service
-import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 
@@ -57,21 +56,18 @@ class GosysOppgaveService(
 
     fun updateGosysOppgave(
         gosysOppgaveId: Long,
-        frist: LocalDate,
-        tildeltSaksbehandlerIdent: String?
+        tildeltSaksbehandlerIdent: String?,
     ) {
         val currentUserIdent = tokenUtil.getCurrentIdent()
         val currentUserInfo = microsoftGraphService.getSaksbehandlerPersonligInfo(navIdent = currentUserIdent)
         val currentGosysOppgave = gosysOppgaveClient.getGosysOppgave(gosysOppgaveId = gosysOppgaveId)
 
-        val newComment = "Overførte oppgaven fra Kabin til Kabal."
-
-        var newBeskrivelsePart = "$newComment\nOppdaterte frist."
+        var comment = "Overførte oppgaven fra Kabin til Kabal."
 
         val (tilordnetRessurs, tildeltEnhetsnr) = if (tildeltSaksbehandlerIdent != null) {
             val tildeltSaksbehandlerInfo =
                 microsoftGraphService.getSaksbehandlerPersonligInfo(tildeltSaksbehandlerIdent)
-            newBeskrivelsePart += "\nTildelte oppgaven til $tildeltSaksbehandlerIdent."
+            comment += "\nTildelte oppgaven til $tildeltSaksbehandlerIdent."
             tildeltSaksbehandlerIdent to tildeltSaksbehandlerInfo.enhet.enhetId
         } else {
             null to null
@@ -80,32 +76,18 @@ class GosysOppgaveService(
             gosysOppgaveId = gosysOppgaveId,
             updateGosysOppgaveInput = UpdateGosysOppgaveInput(
                 versjon = currentGosysOppgave.versjon,
-                fristFerdigstillelse = frist,
-                mappeId = null,
                 endretAvEnhetsnr = currentUserInfo.enhet.enhetId,
                 tilordnetRessurs = tilordnetRessurs,
                 tildeltEnhetsnr = tildeltEnhetsnr,
                 beskrivelse = getNewBeskrivelse(
-                    newBeskrivelsePart = newBeskrivelsePart,
+                    newBeskrivelsePart = comment,
                     existingBeskrivelse = currentGosysOppgave.beskrivelse,
                     currentUserInfo = currentUserInfo
                 ),
                 kommentar = UpdateGosysOppgaveInput.Kommentar(
-                    tekst = newComment,
+                    tekst = comment,
                     automatiskGenerert = true
                 ),
-                tema = null,
-                prioritet = null,
-                orgnr = null,
-                status = null,
-                behandlingstema = null,
-                behandlingstype = null,
-                aktivDato = null,
-                oppgavetype = null,
-                journalpostId = null,
-                saksreferanse = null,
-                behandlesAvApplikasjon = null,
-                personident = null,
             )
         )
     }

--- a/src/main/kotlin/no/nav/klage/service/KlageService.kt
+++ b/src/main/kotlin/no/nav/klage/service/KlageService.kt
@@ -78,7 +78,6 @@ class KlageService(
                 logger.debug("Attempting Gosys-oppgave update")
                 gosysOppgaveService.updateGosysOppgave(
                     gosysOppgaveId = it,
-                    frist = frist,
                     tildeltSaksbehandlerIdent = registrering.saksbehandlerIdent,
                 )
             }


### PR DESCRIPTION
Removed unused fields in Gosys request.