### PR TITLE
Korriger url for kall til logiskVedlegg på dokarkiv

### DIFF
--- a/src/main/kotlin/no/nav/klage/clients/dokarkiv/DokArkivClient.kt
+++ b/src/main/kotlin/no/nav/klage/clients/dokarkiv/DokArkivClient.kt
@@ -123,7 +123,7 @@ class DokArkivClient(
     ): AddLogiskVedleggResponse {
         try {
             val response = dokArkivWebClient.post()
-                .uri("/dokumentInfo/${dokumentInfoId}/logiskVedlegg/")
+                .uri("/dokumentInfo/${dokumentInfoId}/logiskVedlegg")
                 .header(
                     HttpHeaders.AUTHORIZATION,
                     "Bearer ${tokenUtil.getOnBehalfOfTokenWithDokArkivScope()}"


### PR DESCRIPTION
Dokarkiv vil snart ikke godta URL-er med trailing slash, derfor må dette endres